### PR TITLE
Fix PlayerAuthInput and BiomeDefinitionList encoding/decoding

### DIFF
--- a/zuri_net/src/proto/packet/biome_definition_list.rs
+++ b/zuri_net/src/proto/packet/biome_definition_list.rs
@@ -12,10 +12,10 @@ pub struct BiomeDefinitionList {
 
 impl PacketType for BiomeDefinitionList {
     fn write(&self, writer: &mut Writer) {
-        writer.byte_slice(&self.serialised_biome_definitions);
+        writer.bytes(&self.serialised_biome_definitions);
     }
 
     fn read(reader: &mut Reader) -> Self {
-        Self { serialised_biome_definitions: reader.byte_slice() }
+        Self { serialised_biome_definitions: reader.bytes() }
     }
 }

--- a/zuri_net/src/proto/packet/player_auth_input.rs
+++ b/zuri_net/src/proto/packet/player_auth_input.rs
@@ -122,7 +122,7 @@ impl PacketType for PlayerAuthInput {
         writer.var_u64(self.input_data);
         writer.var_u32(self.input_mode.to_u32().unwrap());
         writer.var_u32(self.play_mode.to_u32().unwrap());
-        writer.i32(self.interaction_model.to_i32().unwrap());
+        writer.var_i32(self.interaction_model.to_i32().unwrap());
         if self.play_mode == PlayMode::Reality {
             writer.vec3(self.gaze_direction);
         }
@@ -151,7 +151,7 @@ impl PacketType for PlayerAuthInput {
             input_data: reader.var_u64(),
             input_mode: InputMode::from_u32(reader.var_u32()).unwrap(),
             play_mode: PlayMode::from_u32(reader.var_u32()).unwrap(),
-            interaction_model: InteractionModel::from_i32(reader.i32()).unwrap(),
+            interaction_model: InteractionModel::from_i32(reader.var_i32()).unwrap(),
             gaze_direction: Vec3::default(),
             tick: reader.var_u64(),
             delta: reader.vec3(),


### PR DESCRIPTION
<!--
Remember to add one of these tags bug-fix / new-feature / major release.
-->

<!-- Make sure you fill in the release notes! -->

-- begin release notes --
The interaction model field is now properly encoded/decoded in the PlayerAuthInput packet
The BiomeDefinitionList packet is now properly encoded/decoded
-- end release notes --
